### PR TITLE
Added  code for performing chromatogram alignment

### DIFF
--- a/analysis/alignment/chromatogram_alignment.py
+++ b/analysis/alignment/chromatogram_alignment.py
@@ -6,7 +6,7 @@ import argparse
 import msproteomicstoolslib.math.Smoothing as smoothing
 from msproteomicstoolslib.version import __version__ as version
 from msproteomicstoolslib.math.chauvenet import chauvenet
-from msproteomicstoolslib.format.TransformationCollection import TransformationCollection, LightTransformationData
+
 from msproteomicstoolslib.algorithms.alignment.Multipeptide import Multipeptide
 from msproteomicstoolslib.algorithms.alignment.MRExperiment import MRExperiment
 from msproteomicstoolslib.algorithms.alignment.AlignmentAlgorithm import AlignmentAlgorithm
@@ -24,6 +24,7 @@ from msproteomicstoolslib.algorithms.alignment.SplineAligner import SplineAligne
 import matplotlib.pyplot as plt
 fig = plt.figure()
 plt.close()
+from msproteomicstoolslib.format.TransformationCollection import initialize_transformation
 from pyopenms import OnDiscMSExperiment
 from analysis.chromatogram_utils.smooth_chromatograms import chromSmoother
 from analysis.alignment.reference_run_selection import referenceForPrecursor
@@ -33,18 +34,6 @@ from msproteomicstoolslib.algorithms.alignment.AlignmentHelper import write_out_
 from msproteomicstoolslib.algorithms.alignment.AlignmentAlgorithm import AlignmentAlgorithm
 
 
-def initialize_transformation():
-    # Initialize objects to get transformation
-    try:
-        from msproteomicstoolslib.cython.LightTransformationData import CyLightTransformationData
-        if optimized_cython:
-            tr_data = CyLightTransformationData()
-        else:
-            tr_data = LightTransformationData()
-    except ImportError:
-        print("WARNING: cannot import CyLightTransformationData, will use Python version (slower).")
-        tr_data = LightTransformationData()
-    return tr_data
 
 # Build a chromatogram extractor class
 # It has params: mz, max_chromlength

--- a/analysis/alignment/chromatogram_alignment.py
+++ b/analysis/alignment/chromatogram_alignment.py
@@ -174,7 +174,7 @@ def main(options):
     # reader.map_infiles_chromfiles(chromatograms)
     runs = reader.parse_files()
     MStoFeature = MSfileRunMapping(chromatograms, runs)
-    precursor_to_transitionID = getPrecursorTransitionMapping(infiles[0])
+    precursor_to_transitionID, precursor_sequence = getPrecursorTransitionMapping(infiles[0])
     MZs = mzml_accessors(runs, MStoFeature)
     MZs.get_precursor_to_chromID(precursor_to_transitionID)
 
@@ -209,7 +209,7 @@ def main(options):
             continue
         XICs_ref_sm = chrom_smoother.smoothXICs(XICs_ref)
         # For each precursor, we need peptide_group_label and trgr_id
-        peptide_group_label = precursor_to_transitionID[prec_id][0]
+        peptide_group_label = precursor_sequence[prec_id][0]
         # Iterate through all other runs and align them to the reference run
         for eXprun in eXps:
             ## Extract XICs from experiment run and smooth it.
@@ -231,7 +231,7 @@ def main(options):
                         aligned_fdr_cutoff = options.aligned_fdr_cutoff, method = options.method)
     al = this_exp.print_stats(multipeptides, 0.05, 0.1, 1)
     write_out_matrix_file(options.matrix_outfile, runs, multipeptides, options.min_frac_selected,
-                         options.matrix_output_method, 0.05)
+                         options.matrix_output_method, True, 0.05, precursor_sequence)
 
 if __name__=="__main__":
     options = handle_args()

--- a/analysis/alignment/chromatogram_alignment.py
+++ b/analysis/alignment/chromatogram_alignment.py
@@ -16,6 +16,7 @@ from msproteomicstoolslib.algorithms.alignment.FDRParameterEstimation import Par
 from msproteomicstoolslib.algorithms.PADS.MinimumSpanningTree import MinimumSpanningTree
 
 import numpy as np
+import pandas as pd
 from analysis.alignment.feature_alignment import Experiment
 from msproteomicstoolslib.format.SWATHScoringReader import *
 from msproteomicstoolslib.format.SWATHScoringMapper import MSfileRunMapping, getPrecursorTransitionMapping
@@ -25,6 +26,9 @@ fig = plt.figure()
 plt.close()
 from pyopenms import OnDiscMSExperiment
 import msproteomicstoolslib.math.Smoothing as smoothing
+from DIAlignPy import AffineAlignObj, alignChromatogramsCpp
+from msproteomicstoolslib.format.TransformationCollection import TransformationCollection, LightTransformationData
+from msproteomicstoolslib.algorithms.alignment.AlignmentHelper import addDataToTrafo
 
 # Get a single reference run
 def get_reference_run(experiment, multipeptides, alignment_fdr_threshold = 0.05):
@@ -104,13 +108,50 @@ def get_multipeptide_reference_run(multipeptides, alignment_fdr_threshold = 0.05
     return reference_run
 
 
+def initialize_transformation():
+    # Initialize objects to get transformation
+    try:
+        from msproteomicstoolslib.cython.LightTransformationData import CyLightTransformationData
+        if optimized_cython:
+            tr_data = CyLightTransformationData()
+        else:
+            tr_data = LightTransformationData()
+    except ImportError:
+        print("WARNING: cannot import CyLightTransformationData, will use Python version (slower).")
+        tr_data = LightTransformationData()
+    return tr_data
+
+def get_pair_trafo(tr_data, spl_aligner, run_0, run_1, multipeptides,
+                    max_rt_diff = 30, force = False, optimized_cython = False):
+    """
+    Returns the smoothing object that aligns run1 against run0.
+    """
+    run0_id = run_0.get_id()
+    run1_id = run_1.get_id()
+    # Add pairwise transformation if not found
+    tmp = tr_data.trafo.get(run1_id, {})
+    if not tmp.get(run0_id):
+        addDataToTrafo(tr_data, run_0, run_1, spl_aligner, multipeptides,
+                        realign_method = spl_aligner.smoother, max_rt_diff = max_rt_diff, force=force)
+    return tr_data.getTrafo(run1_id, run0_id), tr_data.getStdev(run1_id, run0_id)
+
 def extractXIC_group(mz, chromIndices):
     """ Extract chromatograms for chromatrogram indices """
     XIC_group = [None]*len(chromIndices)
     for i in range(len(chromIndices)):
         # Chromatogram is a tuple (time_array, intensity_array) of numpy array
+        # mz.getChromatogramById(chromIndices[i]).getIntensityArray()
+        # mz.getChromatogramById(chromIndices[i]).getTimeArray()
         XIC_group[i] = mz.getChromatogram(chromIndices[i]).get_peaks()
     return XIC_group
+
+def get_aligned_time(t, indices, skipValue = -1):
+    t_aligned = [None]*len(indices)
+    for i in range(len(indices)):
+        index = indices[i]
+        if index != skipValue:
+            t_aligned[i] = t[index]
+    return t_aligned
 
 infiles = ["../DIAlignR/inst/extdata/osw/merged.osw"]
 chromatograms = ["../DIAlignR/inst/extdata/mzml/hroest_K120808_Strep10%PlasmaBiolRepl1_R03_SW_filt.chrom.mzML",
@@ -139,21 +180,22 @@ for run in runs:
     chrom_file_accessor[run.get_id()] = mz
 
 # Get precursor to chromatogram indices
+invalid_chromIndex = -1
 run_chromIndex_map = {}
 for run in runs:
     meta_data = chrom_file_accessor[run.get_id()].getMetaData()
     precursor_to_chromIndex = {}
     # Initialize chromatogram indices with -1
     for prec in precursor_to_transitionID:
-        precursor_to_chromIndex[prec] = [-1]*len(precursor_to_transitionID[prec])
+        precursor_to_chromIndex[prec] = [invalid_chromIndex]*len(precursor_to_transitionID[prec][1])
     # Iterate through Native IDs in mzML file
     for i in range(meta_data.getNrChromatograms()):
         nativeID = int(meta_data.getChromatogram(i).getNativeID())
         # Check if Native ID matches to any of our transition IDs.
         for prec in precursor_to_transitionID:
-            if nativeID in precursor_to_transitionID[prec]:
+            if nativeID in precursor_to_transitionID[prec][1]:
                 # Find the index of transition ID and insert chromatogram index
-                index = precursor_to_transitionID[prec].index(nativeID)
+                index = precursor_to_transitionID[prec][1].index(nativeID)
                 precursor_to_chromIndex[prec][index] = i
     run_chromIndex_map[run.get_id()] = precursor_to_chromIndex
 
@@ -171,7 +213,7 @@ reference_run = get_multipeptide_reference_run(multipeptides, alignment_fdr_thre
 
 # Pairwise global alignment
 spl_aligner = SplineAligner(alignment_fdr_threshold = 0.05, smoother="lowess", experiment=this_exp)
-spl_aligner.initialize_transformation_error()
+tr_data = initialize_transformation()
 # Initialize XIC smoothing function
 sm = smoothing.getXIC_SmoothingObj(smoother = "sgolay", kernelLen = 11, polyOrd = 4)
 def smoothXICs(XIC_Group, sm):
@@ -182,49 +224,100 @@ def smoothXICs(XIC_Group, sm):
         XIC_Group_sm.append(XIC_sm)
     return XIC_Group_sm
 
-# Use multiprocessing tool for extracting chromatograms
-prec_id = 9719 #, 9720
+# TODO Use multiprocessing tool for extracting chromatograms
 RSEdistFactor = 4
-for prec_id in precursor_to_transitionID:
-    refrun = reference_run[prec_id]
+# Calculate the aligned retention time for each precursor across all runs
+prec_ids = list(precursor_to_transitionID.keys())
+retention_time = {}
+for run in runs:
+    retention_time[run.get_id()] = [None]*len(prec_ids)
+
+for i in range(len(prec_ids)):
+    prec_id = prec_ids[i]
+    refrun = reference_run.get(prec_id)
+    if not refrun:
+        print("The precursor {} doesn't have any associated reference run. Skipping!".format(prec_id))
+        continue
     eXps = list(set(runs) - set([refrun]))
     # Extract XICs from reference run
     refrun_id = refrun.get_id()
     chrom_ids = run_chromIndex_map[refrun_id][prec_id]
+    if invalid_chromIndex in chrom_ids:
+        print("Can't extract XICs for precursor {} from run {}. Skipping!".format(prec_id, refrun_id))
+        continue
     XICs_ref = extractXIC_group(chrom_file_accessor[refrun_id], chrom_ids)
     XICs_ref_sm = smoothXICs(XICs_ref, sm)
+    # For each precursor, we need peptide_group_label and trgr_id
+    peptide_group_label = precursor_to_transitionID[prec_id][0]
+    refRT = refrun.getPrecursor(peptide_group_label, prec_id).get_best_peakgroup().get_normalized_retentiontime()
+    retention_time[refrun_id][i] = refRT
+    # Get the retention time of the precursor from reference run
+    # refRT = best_feature_RT()
     # Iterate through all other runs and align them to the reference run
     for eXprun in eXps:
         ## Extract XICs from experiment run
         eXprun_id = eXprun.get_id()
         chrom_ids = run_chromIndex_map[eXprun_id][prec_id]
+        if invalid_chromIndex in chrom_ids:
+            print("Can't extract XICs for precursor {} from run {}".format(prec_id, refrun_id))
+            continue
         XICs_eXp = extractXIC_group(chrom_file_accessor[eXprun_id], chrom_ids)
         XICs_eXp_sm = smoothXICs(XICs_eXp, sm)
         # Get time component
         t_ref = XICs_ref_sm[0][0]
         t_eXp = XICs_eXp_sm[0][0]
         ## Set up constraints for penalizing similarity matrix
+        # Get RT tranfromation from refrun to eXprun.
+        globalAligner, stdErr = get_pair_trafo(tr_data, spl_aligner, eXprun, refrun, multipeptides, max_rt_diff = 300)
         # Get constraining end-points using Global alignment
-        globalAligner = spl_aligner.rt_align_pair(refrun, eXprun, multipeptides)
-        B1p = globalAligner.predict([ t_ref[0] ])
-        B2p = globalAligner.predict([ t_ref[-1] ])
+        B1p = globalAligner.predict([ t_ref[0] ])[0]
+        B2p = globalAligner.predict([ t_ref[-1] ])[0]
         # Get width of the constraining window
-        adaptiveRT = RSEdistFactor * spl_aligner.transformation_error.transformations[refrun_id][eXprun_id][0]
+        adaptiveRT = RSEdistFactor * stdErr
         samplingTime = (t_ref[-1] - t_ref[0]) / (len(t_ref) - 1)
         noBeef = np.ceil(adaptiveRT/samplingTime)
         ## Get intensity values to build similarity matrix
-        intensityList_ref = np.array([xic[1] for xic in XICs_ref_sm])
-        intensityList_eXp = np.array([xic[1] for xic in XICs_eXp_sm])
+        intensityList_ref = np.array([xic[1] for xic in XICs_ref_sm], dtype=np.double)
+        intensityList_eXp = np.array([xic[1] for xic in XICs_eXp_sm], dtype=np.double)
         intensityList_ref = np.ascontiguousarray(intensityList_ref)
         intensityList_eXp = np.ascontiguousarray(intensityList_eXp)
+        chromAlignObj = AffineAlignObj(256, 256)
+        alignChromatogramsCpp(chromAlignObj, intensityList_ref, intensityList_eXp,
+                                    alignType = b"hybrid", tA = t_ref, tB = t_eXp,
+                                    normalization = b"mean", simType = b"dotProductMasked",
+                                    B1p = B1p, B2p = B2p, noBeef = noBeef,
+                                    goFactor = 0.125, geFactor = 40,
+                                    cosAngleThresh = 0.3, OverlapAlignment = True,
+                                    dotProdThresh = 0.96, gapQuantile = 0.5,
+                                    hardConstrain = False, samples4gradient = 100)
+        AlignedIndices = pd.DataFrame(list(zip(chromAlignObj.indexA_aligned, chromAlignObj.indexB_aligned)),
+	                                    columns =['indexAligned_ref', 'indexAligned_eXp'])
+        AlignedIndices['indexAligned_ref'] -= 1
+        AlignedIndices['indexAligned_eXp'] -= 1
+        t_ref_aligned = get_aligned_time(t_ref, AlignedIndices['indexAligned_ref'])
+        t_ref_aligned = pd.Series(t_ref_aligned).interpolate(method ='linear', limit_area = 'inside')
+        t_eXp_aligned = get_aligned_time(t_eXp, AlignedIndices['indexAligned_eXp'])
+        t_eXp_aligned = pd.Series(t_eXp_aligned).interpolate(method ='linear', limit_area = 'inside')
+        t_ref_aligned = np.asarray(t_ref_aligned)
+        index = np.nanargmin(np.abs(t_ref_aligned - refRT))
+        eXpRT = t_eXp_aligned[index]
+        retention_time[eXprun_id][i] = eXpRT
 
-    
-    
-# Iterate through each precursor and get the alignment.
-    #Get smoothing from SplineAligner. Check if smoothing is already present.
-    #calculate AdaptiveRT
-    #getAlignObj function that calls DIAlignPy
-    # SplineAligner.py _spline_align_runs(self, bestrun, run, multipeptides)
+retention_time = pd.DataFrame.from_dict(retention_time)
+retention_time = retention_time.dropna(how='all')
+"""
+B1p = 19.955
+B2p = 49.998
+noBeef = 20.0
+t_ref = np.array([9.9, 13.3, 16.7, 20.1, 23.5, 26.9, 30.4, 33.8, 37.2, 40.6])
+t_eXp = np.array([9.9, 13.3, 16.7, 20.1, 23.5, 26.9, 30.4, 33.8, 37.2, 40.6])
+intensityList_ref = np.array([[1,2,3,2,1,0,0,0,0,0]], dtype = np.double)
+intensityList_eXp = np.array([[0,0,0,0,1,2,3,2,1,0]], dtype = np.double)
+chromAlignObj = AffineAlignObj(256, 256)
+
+chromAlignObj.indexA_aligned # [0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+chromAlignObj.indexB_aligned # [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 10]
+"""
 
 fig = plt.figure()
 XIC_Group = XICs_ref_sm

--- a/analysis/alignment/chromatogram_alignment.py
+++ b/analysis/alignment/chromatogram_alignment.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+# -*- coding: utf-8  -*-
+import os, sys, csv, time
+import numpy
+import argparse
+import msproteomicstoolslib.math.Smoothing as smoothing
+from msproteomicstoolslib.version import __version__ as version
+from msproteomicstoolslib.math.chauvenet import chauvenet
+from msproteomicstoolslib.format.TransformationCollection import TransformationCollection, LightTransformationData
+from msproteomicstoolslib.algorithms.alignment.Multipeptide import Multipeptide
+from msproteomicstoolslib.algorithms.alignment.MRExperiment import MRExperiment
+from msproteomicstoolslib.algorithms.alignment.AlignmentAlgorithm import AlignmentAlgorithm
+from msproteomicstoolslib.algorithms.alignment.AlignmentMST import getDistanceMatrix, TreeConsensusAlignment
+from msproteomicstoolslib.algorithms.alignment.AlignmentHelper import write_out_matrix_file, addDataToTrafo
+from msproteomicstoolslib.algorithms.alignment.SplineAligner import SplineAligner
+from msproteomicstoolslib.algorithms.alignment.FDRParameterEstimation import ParamEst
+from msproteomicstoolslib.algorithms.PADS.MinimumSpanningTree import MinimumSpanningTree
+
+from analysis.alignment.feature_alignment import Experiment
+from msproteomicstoolslib.format.SWATHScoringReader import *
+from msproteomicstoolslib.format.SWATHScoringMapper import MSfileRunMapping, getPrecursorTransitionMapping
+#from analysis.alignment.chromatogram_alignment import get_reference_run, get_precursor_reference_run, get_multipeptide_reference_run
+
+# Get a single reference run
+def get_reference_run(experiment, multipeptides, alignment_fdr_threshold = 0.05):
+    """
+    Returns a dectionary with precursor id as key and run as value.
+    Single reference run for each precursor.
+    """
+    best_run = experiment.determine_best_run(alignment_fdr_threshold = 0.05)
+    reference_run = {}
+    precursor_ids = set()
+    for i in range(len(multipeptides)):
+        # Get precursor groups from each multipeptide
+        prec_groups =  multipeptides[i].getPrecursorGroups()
+        for prec_group in prec_groups:
+            # Get precursors from a precursor group
+            precs = prec_group.getAllPrecursors()
+            for prec in precs:
+                # Get all precursor ids
+                precursor_ids.add(prec.get_id())
+    # Get a sorted list
+    precursor_ids = sorted(precursor_ids)
+    # Assign best_run as reference run for each precursor_id
+    reference_run = dict.fromkeys(precursor_ids , best_run)
+    return reference_run    
+
+# Get reference run for each precursor
+def get_precursor_reference_run(multipeptides, alignment_fdr_threshold = 0.05):
+    """
+    Returns a dectionary with precursor id as key and run as value.
+    Precursors may have different reference runs based on FDR score of associated best peak group.
+    """
+    reference_run = {}
+    for i in range(len(multipeptides)):
+        # Get precursor groups from each multipeptide
+        prec_groups =  multipeptides[i].getPrecursorGroups()
+        for prec_group in prec_groups:
+            # Get precursors from a precursor group
+            precs = prec_group.getAllPrecursors()
+            max_fdr = 1.0
+            for prec in precs:
+                # Get all precursor ids
+                prec_id = prec.get_id()
+                # Get best FDR value for the precursor
+                cur_fdr = prec.get_best_peakgroup().get_fdr_score()
+                if cur_fdr <= alignment_fdr_threshold and cur_fdr < max_fdr:
+                    max_fdr = cur_fdr
+                    # Make Run of the current precursor as the reference run
+                    reference_run[prec_id] = prec.getRun()
+            if prec_id not in reference_run:
+                # No peak group has FDR lower than alignment_fdr_threshold
+                reference_run[prec_id] = None
+    return reference_run
+
+# Get reference run for each precursor-group
+def get_multipeptide_reference_run(multipeptides, alignment_fdr_threshold = 0.05):
+    """
+    Returns a dectionary with precursor id as key and run as value.
+    Precursors may have different reference runs based on FDR score of associated multipeptide's best peak group.
+    """
+    reference_run = {}
+    for i in range(len(multipeptides)):
+        # Get precursor groups from each multipeptide
+        prec_groups =  multipeptides[i].getPrecursorGroups()
+        max_fdr = 1.0
+        refRun = None
+        for prec_group in prec_groups:
+            precs = prec_group.getAllPrecursors()
+            cur_fdr = prec_group.getOverallBestPeakgroup().get_fdr_score()
+            if cur_fdr <= alignment_fdr_threshold and cur_fdr < max_fdr:
+                max_fdr = cur_fdr
+                refRun = prec_group.run_
+            for prec in precs:
+                # Get all precursor ids
+                prec_id = prec.get_id()
+                # Make Run of the current precursor as the reference run
+                reference_run[prec_id] = refRun
+    return reference_run
+
+
+infiles = ["../DIAlignR/inst/extdata/osw/merged.osw"]
+chromatograms = ["../DIAlignR/inst/extdata/mzml/hroest_K120808_Strep10%PlasmaBiolRepl1_R03_SW_filt.chrom.mzML",
+ "../DIAlignR/inst/extdata/mzml/hroest_K120809_Strep10%PlasmaBiolRepl2_R04_SW_filt.chrom.mzML",
+ "../DIAlignR/inst/extdata/mzml/hroest_K120809_Strep0%PlasmaBiolRepl2_R04_SW_filt.chrom.mzML"]
+
+readfilter = ReadFilter()
+file_format = 'openswath'
+readmethod = "minimal"
+
+reader = SWATHScoringReader.newReader(infiles, file_format, readmethod, readfilter,
+                                        enable_isotopic_grouping = False, read_cluster_id = False)
+# reader.map_infiles_chromfiles(chromatograms)
+runs = reader.parse_files()
+MStoFeature = MSfileRunMapping(chromatograms, runs)
+# MStoFeature[runs[0].get_openswath_filename()][0]
+precursor_mapping = getPrecursorTransitionMapping(infiles[0])
+
+this_exp = Experiment()
+this_exp.set_runs(runs)
+start = time.time()
+fdr_cutoff = 0.05
+multipeptides = this_exp.get_all_multipeptides(fdr_cutoff, verbose=False, verbosity= 10)
+print("Mapping the precursors took %0.2fs" % (time.time() - start) )
+
+# Reference based alignment
+reference_run = get_reference_run(this_exp, multipeptides, alignment_fdr_threshold = 0.05)
+reference_run = get_precursor_reference_run(multipeptides, alignment_fdr_threshold = 0.05)
+reference_run = get_multipeptide_reference_run(multipeptides, alignment_fdr_threshold = 0.05)
+
+# Iterate through each precursor and get the alignment.
+    #Get precursor id
+    #Get associated transition id
+    #Extract XICs using pyopenms
+    #smooth XICs using pyopenms
+    #Get smoothing from SplineAligner. Check if smoothing is already present.
+    #calculate AdaptiveRT
+    #getAlignObj function that calls DIAlignPy
+    # SplineAligner.py _spline_align_runs(self, bestrun, run, multipeptides)
+
+
+for i in range(len(multipeptides)):
+    for run in runs:
+        id = run.get_id()
+        prec = multipeptides[0].getPrecursorGroup(id).getAllPrecursors()
+        
+
+
+
+options = handle_args()
+
+# python ./analysis/alignment/chromatogram_alignment.py --in file1_input.csv file2_input.csv file3_input.csv --out aligned.csv  --method best_overall --max_rt_diff 90 --target_fdr 0.01 --max_fdr_quality 0.05
+
+# multipeptides[i].get_peptides()[j].get_run()
+#                                   .get_precursors()
+
+getAllPeptides # Returns a list of Precursor from each run. How come there are only three?
+getPrecursorGroup
+getPrecursorGroups
+
+
+runs[0].get_id() # 125704171604355508
+runs[1].get_id() # 6752973645981403097
+runs[2].get_id() # 2234664662238281994
+
+multipeptides[0].getPrecursorGroup(6752973645981403097)
+multipeptides[0].getPrecursorGroup(2234664662238281994).getOverallBestPeakgroup().get_fdr_score()
+multipeptides[0].getPrecursorGroup(2234664662238281994).getAllPrecursors()[0].get_best_peakgroup().get_fdr_score()
+
+id = multipeptides[0].getPrecursorGroup(2234664662238281994).getAllPrecursors()[0].get_id()
+id = 9719
+id = 9720
+chromid = precursor_mapping[id]
+
+run = pymzml.run.Reader(chromatograms[0], build_index_from_scratch=True)
+run.info["seekable"]
+run.info["offsets"].items()
+run[str(chromid[0])].peaks
+
+getOverallBestPeakgroup
+getAllPrecursors
+getAllPeakgroups

--- a/analysis/alignment/chromatogram_alignment.py
+++ b/analysis/alignment/chromatogram_alignment.py
@@ -1,19 +1,37 @@
 #!/usr/bin/env python
 # -*- coding: utf-8  -*-
+"""
+=========================================================================
+        DIAlignPy -- Alignment of Targeted Mass Spectrometry Runs
+=========================================================================
+
+<Shubham Gupta reference_run_selection.py>
+Copyright (C) 2020 Shubham Gupta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------
+$Maintainer: Shubham Gupta$
+$Authors: Shubham Gupta$
+--------------------------------------------------------------------------
+"""
 import os, sys, csv, time
 
 import argparse
 import msproteomicstoolslib.math.Smoothing as smoothing
 from msproteomicstoolslib.version import __version__ as version
 from msproteomicstoolslib.math.chauvenet import chauvenet
-
-from msproteomicstoolslib.algorithms.alignment.Multipeptide import Multipeptide
-from msproteomicstoolslib.algorithms.alignment.MRExperiment import MRExperiment
-from msproteomicstoolslib.algorithms.alignment.AlignmentAlgorithm import AlignmentAlgorithm
-from msproteomicstoolslib.algorithms.alignment.AlignmentMST import getDistanceMatrix, TreeConsensusAlignment
-from msproteomicstoolslib.algorithms.alignment.AlignmentHelper import write_out_matrix_file, addDataToTrafo
-from msproteomicstoolslib.algorithms.alignment.FDRParameterEstimation import ParamEst
-from msproteomicstoolslib.algorithms.PADS.MinimumSpanningTree import MinimumSpanningTree
 
 import numpy as np
 import pandas as pd

--- a/analysis/alignment/feature_alignment.py
+++ b/analysis/alignment/feature_alignment.py
@@ -475,6 +475,26 @@ class Experiment(MRExperiment):
                 myYaml["RawData"].append(this)
             open(yaml_outfile, 'w').write(yaml.dump({"AlignedSwathRuns" : myYaml}))
 
+    def determine_best_run(self, alignment_fdr_threshold):
+        """
+        Returns the run that has the highest number of high-scoring (below certain FDR) peakgroups.  
+        """
+        maxcount = -1
+        bestrun = -1
+        for run in self.runs:
+            cnt = 0
+            for prgroup in run:
+                for peptide in prgroup:
+                    if peptide.get_decoy(): continue
+                    pg = peptide.get_best_peakgroup()
+                    if pg.get_fdr_score() < alignment_fdr_threshold:
+                        cnt += 1
+            if cnt > maxcount:
+                maxcount = cnt
+                bestrun = run.get_id()
+        print("Found best run", bestrun, "with %s features above the cutoff of %s%%" % (maxcount, alignment_fdr_threshold))
+        return [r for r in self.runs if r.get_id() == bestrun][0]
+
 def estimate_aligned_fdr_cutoff(options, this_exp, multipeptides, fdr_range):
     print("Try to find parameters for target fdr %0.2f %%" % (options.target_fdr * 100))
 

--- a/analysis/alignment/reference_run_selection.py
+++ b/analysis/alignment/reference_run_selection.py
@@ -31,24 +31,22 @@ class referenceForPrecursor():
     """
     Calculates reference run for each precursor.
     Returns a dictionary with Precursor_id as key and Run as value.
+    refType must be either best_run, multipeptide_specific or precursor_specific.
     """
     def __init__(self, refType="best_run", run = None, alignment_fdr_threshold = 0.05):
-        """
-        refType must be either best_run, multipeptide_specific or precursor_specific. 
-        """
         self.referenceType = refType
         self.alignment_fdr_threshold = alignment_fdr_threshold
-        if(refType == "best_run"):
-            if not run:
-                raise Exception("run should be provided if refType is best_run.")
-            self.best_run = run
+        self.best_run = run
 
-    def get_reference_for_precursors(self, multipeptides, refType = "best_run"):
-        if (refType == "best_run"):
-            return self._get_reference_run(multipeptides)
-        elif (refType == "precursor_specific"):
+    def get_reference_for_precursors(self, multipeptides):
+        if (self.referenceType == "best_run"):
+            if not self.best_run:
+                raise Exception("run should be provided with initialization if refType is best_run.")
+            else:
+                return self._get_reference_run(multipeptides)
+        elif (self.referenceType == "precursor_specific"):
             return self._get_precursor_reference_run(multipeptides)
-        elif (refType == "multipeptide_specific"):
+        elif (self.referenceType == "multipeptide_specific"):
             return self._get_multipeptide_reference_run(multipeptides)
         else:
             raise Exception("refType must be either best_run, multipeptide_specific or precursor_specific.")

--- a/analysis/alignment/reference_run_selection.py
+++ b/analysis/alignment/reference_run_selection.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""
+=========================================================================
+        DIAlignPy -- Alignment of Targeted Mass Spectrometry Runs
+=========================================================================
+
+<Shubham Gupta reference_run_selection.py>
+Copyright (C) 2020 Shubham Gupta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------
+$Maintainer: Shubham Gupta$
+$Authors: Shubham Gupta$
+--------------------------------------------------------------------------
+"""
+
+class referenceForPrecursor():
+    """
+    Calculates reference run for each precursor.
+    Returns a dictionary with Precursor_id as key and Run as value.
+    """
+    def __init__(self, refType="best_run", run = None, alignment_fdr_threshold = 0.05):
+        """
+        refType must be either best_run, multipeptide_specific or precursor_specific. 
+        """
+        self.referenceType = refType
+        self.alignment_fdr_threshold = alignment_fdr_threshold
+        if(refType == "best_run"):
+            if not run:
+                raise Exception("run should be provided if refType is best_run.")
+            self.best_run = run
+
+    def get_reference_for_precursors(self, multipeptides, refType = "best_run"):
+        if (refType == "best_run"):
+            return self._get_reference_run(multipeptides)
+        elif (refType == "precursor_specific"):
+            return self._get_precursor_reference_run(multipeptides)
+        elif (refType == "multipeptide_specific"):
+            return self._get_multipeptide_reference_run(multipeptides)
+        else:
+            raise Exception("refType must be either best_run, multipeptide_specific or precursor_specific.")
+
+    # Get a single reference run
+    def _get_reference_run(self, multipeptides):
+        """
+        Returns a dectionary with precursor id as key and run as value.
+        Single reference run for each precursor.
+        """
+        reference_run = {}
+        run_id = self.best_run.get_id()
+        precursor_ids = set()
+        for i in range(len(multipeptides)):
+            # Get all precursors from each multipeptide
+            precs =  multipeptides[i].getAllPeptides()
+            for prec in precs:
+                # Add precursor ID if it is from best_run.
+                if prec.getRunId() == run_id:
+                    precursor_ids.add(prec.get_id())
+        # Get a sorted list
+        precursor_ids = sorted(precursor_ids)
+        # Assign best_run as reference run for each precursor_id
+        reference_run = dict.fromkeys(precursor_ids , self.best_run)
+        return reference_run
+
+    # Get a reference run for each precursor
+    def _get_precursor_reference_run(self, multipeptides):
+        """
+        Returns a dectionary with precursor id as key and run as value.
+        Precursors may have different reference runs based on FDR score of associated best peak group.
+        """
+        reference_run = {}
+        for i in range(len(multipeptides)):
+            # Get precursor groups from each multipeptide
+            prec_groups =  multipeptides[i].getPrecursorGroups()
+            for prec_group in prec_groups:
+                # Get precursors from a precursor group
+                precs = prec_group.getAllPrecursors()
+                max_fdr = 1.0
+                for prec in precs:
+                    # Get all precursor ids
+                    prec_id = prec.get_id()
+                    # Get best FDR value for the precursor
+                    cur_fdr = prec.get_best_peakgroup().get_fdr_score()
+                    if cur_fdr <= self.alignment_fdr_threshold and cur_fdr < max_fdr:
+                        max_fdr = cur_fdr
+                        # Make Run of the current precursor as the reference run
+                        reference_run[prec_id] = prec.getRun()
+                if prec_id not in reference_run:
+                    # No peak group has FDR lower than alignment_fdr_threshold
+                    reference_run[prec_id] = None
+        return reference_run
+
+    # Get a reference run for each precursor-group
+    def _get_multipeptide_reference_run(self, multipeptides):
+        """
+        Returns a dectionary with precursor id as key and run as value.
+        Precursors may have different reference runs based on FDR score of associated multipeptide's best peak group.
+        """
+        reference_run = {}
+        for i in range(len(multipeptides)):
+            # Get precursor groups from each multipeptide
+            prec_groups =  multipeptides[i].getPrecursorGroups()
+            max_fdr = 1.0
+            refRun = None
+            for prec_group in prec_groups:
+                precs = prec_group.getAllPrecursors()
+                cur_fdr = prec_group.getOverallBestPeakgroup().get_fdr_score()
+                if cur_fdr <= self.alignment_fdr_threshold and cur_fdr < max_fdr:
+                    max_fdr = cur_fdr
+                    refRun = prec_group.run_
+                for prec in precs:
+                    # Get all precursor ids
+                    prec_id = prec.get_id()
+                    # Make Run of the current precursor as the reference run
+                    reference_run[prec_id] = refRun
+        return reference_run

--- a/analysis/chromatogram_utils/chromatogramMapper.py
+++ b/analysis/chromatogram_utils/chromatogramMapper.py
@@ -83,14 +83,14 @@ class mzml_accessors():
             precursor_to_chromIndex = {}
             # Initialize chromatogram indices with -1
             for prec in precursor_to_transitionID:
-                precursor_to_chromIndex[prec] = [invalid_chromIndex]*len(precursor_to_transitionID[prec][1])
+                precursor_to_chromIndex[prec] = [invalid_chromIndex]*len(precursor_to_transitionID[prec])
             # Iterate through Native IDs in mzML file
             for i in range(meta_data.getNrChromatograms()):
                 nativeID = int(meta_data.getChromatogram(i).getNativeID())
                 # Check if Native ID matches to any of our transition IDs.
                 for prec in precursor_to_transitionID:
-                    if nativeID in precursor_to_transitionID[prec][1]:
+                    if nativeID in precursor_to_transitionID[prec]:
                         # Find the index of transition ID and insert chromatogram index
-                        index = precursor_to_transitionID[prec][1].index(nativeID)
+                        index = precursor_to_transitionID[prec].index(nativeID)
                         precursor_to_chromIndex[prec][index] = i
             self.run_chromIndex_map[run.get_id()] = precursor_to_chromIndex

--- a/analysis/chromatogram_utils/chromatogramMapper.py
+++ b/analysis/chromatogram_utils/chromatogramMapper.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""
+=========================================================================
+        DIAlignPy -- Alignment of Targeted Mass Spectrometry Runs
+=========================================================================
+
+<Shubham Gupta chromatogramMapper.py>
+Copyright (C) 2020 Shubham Gupta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------
+$Maintainer: Shubham Gupta$
+$Authors: Shubham Gupta$
+--------------------------------------------------------------------------
+"""
+
+from pyopenms import OnDiscMSExperiment
+
+class mz_pointer():
+    def __init__(self, filename):
+        # Establish connection to mzML files
+        mz = OnDiscMSExperiment()
+        mz.openFile(filename)
+        self.filename = filename
+        self.pointer = mz
+        # Get maximum number of chromatogram
+        self.meta_data = mz.getMetaData()
+        self.maxIndex = len(self.meta_data.getChromatograms()) - 1 
+
+    def extractXIC_group_(self, chromIndices):
+        """ Extract chromatograms for chromatrogram indices """
+        XIC_group = [None]*len(chromIndices)
+        for i in range(len(chromIndices)):
+            # Chromatogram is a tuple (time_array, intensity_array) of numpy array
+            # mz.getChromatogramById(chromIndices[i]).getIntensityArray()
+            # mz.getChromatogramById(chromIndices[i]).getTimeArray()
+            if chromIndices[i] > self.maxIndex:
+                print("Warning : Invalid index {} in run {}. Skipping!".format(chromIndices[i], self.filename))
+                continue
+            XIC_group[i] = self.pointer.getChromatogram(chromIndices[i]).get_peaks()
+        return XIC_group
+
+class mzml_accessors():
+    """ Establish connection to mzML files """
+    def __init__(self, runs, MStoFeature):
+        # TODO Should I add the mz accessor to the Run object ?
+        chrom_file_accessor = {}
+        for run in runs:
+            mzml_file = MStoFeature[run.get_openswath_filename()][0]
+            chrom_file_accessor[run.get_id()] = mz_pointer(mzml_file)
+        self.pointers = chrom_file_accessor
+        self.runs = runs
+        self.invalid_chromIndex = -1
+        self.run_chromIndex_map = {}
+    
+    def extractXIC_group(self, run, prec_id):
+        chrom_ids = self.run_chromIndex_map[run.get_id()][prec_id]
+        if self.invalid_chromIndex in chrom_ids:
+            print("Can't extract XICs for precursor {} from run {}. Skipping!".format(prec_id, run.get_id()))
+            return None
+        else:
+            return self.pointers[run.get_id()].extractXIC_group_(chrom_ids)
+
+    def get_precursor_to_chromID(self, precursor_to_transitionID, invalid_chromIndex = -1):
+        self.invalid_chromIndex = invalid_chromIndex
+        # Get precursor to chromatogram indices
+        for run in self.runs:
+            meta_data = self.pointers[run.get_id()].meta_data
+            precursor_to_chromIndex = {}
+            # Initialize chromatogram indices with -1
+            for prec in precursor_to_transitionID:
+                precursor_to_chromIndex[prec] = [invalid_chromIndex]*len(precursor_to_transitionID[prec][1])
+            # Iterate through Native IDs in mzML file
+            for i in range(meta_data.getNrChromatograms()):
+                nativeID = int(meta_data.getChromatogram(i).getNativeID())
+                # Check if Native ID matches to any of our transition IDs.
+                for prec in precursor_to_transitionID:
+                    if nativeID in precursor_to_transitionID[prec][1]:
+                        # Find the index of transition ID and insert chromatogram index
+                        index = precursor_to_transitionID[prec][1].index(nativeID)
+                        precursor_to_chromIndex[prec][index] = i
+            self.run_chromIndex_map[run.get_id()] = precursor_to_chromIndex

--- a/analysis/chromatogram_utils/chromatogramMapper.py
+++ b/analysis/chromatogram_utils/chromatogramMapper.py
@@ -32,6 +32,7 @@ from pyopenms import OnDiscMSExperiment
 class mz_pointer():
     def __init__(self, filename):
         # Establish connection to mzML files
+        # TODO Use multiprocessing tool for extracting chromatograms
         mz = OnDiscMSExperiment()
         mz.openFile(filename)
         self.filename = filename

--- a/analysis/chromatogram_utils/smooth_chromatograms.py
+++ b/analysis/chromatogram_utils/smooth_chromatograms.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""
+=========================================================================
+        DIAlignPy -- Alignment of Targeted Mass Spectrometry Runs
+=========================================================================
+
+<Shubham Gupta smooth_chromatograms.py>
+Copyright (C) 2020 Shubham Gupta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------
+$Maintainer: Shubham Gupta$
+$Authors: Shubham Gupta$
+--------------------------------------------------------------------------
+"""
+
+import msproteomicstoolslib.math.ChromatogramSmoothing as xic_smoothing
+
+class chromSmoother():
+    """
+    Use the ChromatogramSmoothing part of msproteomicstoolslib to smooth a chromatogram-group.
+
+    >>> chrom_smoother = chromSmoother()
+    >>> XIC_Group_sm = chrom_smoother.rt_smoothXICs(XIC_Group)
+    """
+    def __init__(self, smoother="sgolay", kernelLen=11, polyOrd = 4):
+        """
+        Initializes ChromatogramSmoothing with either sgolay, gaussian or loess.
+        kernelLen defines the numbers of neighboring-points to be used by the smoothing function.
+        polyOrd defines the order of the polynomial fit used by the smoothing function.
+        """
+        self.sm = xic_smoothing.getXIC_SmoothingObj(smoother, kernelLen, polyOrd)
+
+    def smoothXICs(self, XIC_Group):
+        """
+        Smooth each element of XIC_Group.
+
+        >>> import math
+        >>> XIC_Group = [(np.array([i for i in range(15)]), np.array([1+math.sin(i) for i in range(15)]))]
+        >>> XIG_Group_sm = chrom_smoother.smoothXICs(XIC_Group)
+        """
+        XIC_Group_sm = []
+        for XIC in XIC_Group:
+            self.sm.initialize(XIC[0], XIC[1])
+            XIC_sm = self.sm.smooth(XIC[0], XIC[1])
+            XIC_Group_sm.append(XIC_sm)
+        return XIC_Group_sm

--- a/msproteomicstoolslib/algorithms/alignment/AlignmentHelper.py
+++ b/msproteomicstoolslib/algorithms/alignment/AlignmentHelper.py
@@ -225,3 +225,17 @@ def addDataToTrafo(tr_data, run_0, run_1, spl_aligner, multipeptides,
         tr_data.addTrafo(id_0, id_1, sm_0_1, stdev_0_1)
         tr_data.addTrafo(id_1, id_0, sm_1_0, stdev_1_0)
 
+def get_pair_trafo(tr_data, spl_aligner, run_0, run_1, multipeptides,
+                    max_rt_diff = 30, force = False, optimized_cython = False):
+    """
+    Returns the smoothing object that aligns run1 against run0.
+    If the object is not present in tr_data, smmothing function is calculated and added to it.
+    """
+    run0_id = run_0.get_id()
+    run1_id = run_1.get_id()
+    # Add pairwise transformation if not found
+    tmp = tr_data.trafo.get(run1_id, {})
+    if not tmp.get(run0_id):
+        addDataToTrafo(tr_data, run_0, run_1, spl_aligner, multipeptides,
+                        realign_method = spl_aligner.smoother, max_rt_diff = max_rt_diff, force=force)
+    return tr_data.getTrafo(run1_id, run0_id), tr_data.getStdev(run1_id, run0_id)

--- a/msproteomicstoolslib/algorithms/alignment/AlignmentHelper.py
+++ b/msproteomicstoolslib/algorithms/alignment/AlignmentHelper.py
@@ -50,11 +50,14 @@ else:
     pass
 
 def write_out_matrix_file(matrix_outfile, allruns, multipeptides, fraction_needed_selected,
-                          style="none", write_requant=True, aligner_mscore_treshold=1.0):
+                          style="none", write_requant=True, aligner_mscore_treshold=1.0, precursor_sequence = None):
     matrix_writer = getwriter(matrix_outfile)
 
     run_ids = [r.get_id() for r in allruns]
-    header = ["Peptide", "Protein"]
+    if precursor_sequence == None:
+        header = ["Peptide", "Protein"]
+    else:
+        header = ["Peptide", "Sequence", "Charge", "Protein"]
     for r in allruns:
         fname = "%s_%s" % (os.path.basename(r.orig_filename), r.get_id() )
         header.extend(["Intensity_%s" % fname])
@@ -95,8 +98,14 @@ def write_out_matrix_file(matrix_outfile, allruns, multipeptides, fraction_neede
                 continue
 
             # Write first two columns of the matrix
-            for i in [trgr_id, multipep.find_best_peptide_pg().getPeptide().getProteinName()]:
-                matrix_writer.write(i)
+            if precursor_sequence == None:
+                for i in [trgr_id, multipep.find_best_peptide_pg().getPeptide().getProteinName()]:
+                    matrix_writer.write(i)
+            else:
+                seque = precursor_sequence[trgr_id][1]
+                charge = precursor_sequence[trgr_id][2]
+                for i in [trgr_id, seque, charge, multipep.find_best_peptide_pg().getPeptide().getProteinName()]:
+                    matrix_writer.write(i)
 
             # Write other columns (one or two per run, depending on format)
             rts = []

--- a/msproteomicstoolslib/algorithms/alignment/SplineAligner.py
+++ b/msproteomicstoolslib/algorithms/alignment/SplineAligner.py
@@ -313,6 +313,10 @@ class SplineAligner():
 
         return self.transformation_collection
 
+    def initialize_transformation_error(self):
+        """Initialzes transformation error (Not sure if it can be moved to __init__)"""
+        self.transformation_error = TransformationError()
+
     def rt_align_pair(self, refrun, eXprun, multipeptides):
         """
         Returns the smoothing object that aligns reference run (refrun) against experiment run (eXprun).
@@ -339,14 +343,12 @@ class SplineAligner():
         self.transformation_collection.addTransformationData([data2, data1], refrun.get_id(), eXprun.get_id() )
         self.transformation_collection.addTransformedData(data2_aligned, refrun.get_id(), eXprun.get_id() )
 
-        stdev = numpy.std(numpy.array(data1) - numpy.array(data2_aligned))
+        RSE = numpy.std(numpy.array(data1) - numpy.array(data2_aligned)) # Residual Standard Error is an estimate of standard-deviation
         median = numpy.median(numpy.array(data1) - numpy.array(data2_aligned))
-        print("Will align run %s against %s, using %s features" % (refrun.get_id(), eXprun.get_id(), len(data1)) )
-        print("  Computed stdev", stdev, "and median", median )
 
         # Store error for later
         d = self.transformation_error.transformations.get(refrun.get_id(), {})
-        d[eXprun.get_id()] = [stdev, median]
+        d[eXprun.get_id()] = [RSE, median]
         self.transformation_error.transformations[ refrun.get_id() ] = d
 
         return sm

--- a/msproteomicstoolslib/algorithms/alignment/SplineAligner.py
+++ b/msproteomicstoolslib/algorithms/alignment/SplineAligner.py
@@ -313,6 +313,44 @@ class SplineAligner():
 
         return self.transformation_collection
 
+    def rt_align_pair(self, refrun, eXprun, multipeptides):
+        """
+        Returns the smoothing object that aligns reference run (refrun) against experiment run (eXprun).
+        """
+
+        sm = smoothing.getSmoothingObj(smoother = self.smoother, tmpdir = self.tmpdir_)
+
+        # get those peptides we want to use for alignment => for this use the mapping
+        # data1 = reference data (master)
+        # data2 = data to be aligned (slave)
+        data1,data2 = self._getRTData(eXprun, refrun, multipeptides)
+        if len(data1) < 2:
+            print("No common identifications between %s and %s. Only found %s features below a cutoff of %s" % ( 
+                refrun.get_id(), eXprun.get_id(), len(data1), self.alignment_fdr_threshold_) )
+            print("If you ran the chromatogram_alignment.py script, try to use local alignment only." )
+            raise Exception("Not enough datapoints (less than 2 datapoints).")
+
+        # Since we want to predict how to convert from slave to master, slave
+        # is first and master is second.
+        sm.initialize(data2, data1)
+        data2_aligned = sm.predict(data2)
+
+        # Store transformation in collection (from refrun to eXprun)
+        self.transformation_collection.addTransformationData([data2, data1], refrun.get_id(), eXprun.get_id() )
+        self.transformation_collection.addTransformedData(data2_aligned, refrun.get_id(), eXprun.get_id() )
+
+        stdev = numpy.std(numpy.array(data1) - numpy.array(data2_aligned))
+        median = numpy.median(numpy.array(data1) - numpy.array(data2_aligned))
+        print("Will align run %s against %s, using %s features" % (refrun.get_id(), eXprun.get_id(), len(data1)) )
+        print("  Computed stdev", stdev, "and median", median )
+
+        # Store error for later
+        d = self.transformation_error.transformations.get(refrun.get_id(), {})
+        d[eXprun.get_id()] = [stdev, median]
+        self.transformation_error.transformations[ refrun.get_id() ] = d
+
+        return sm
+
     def getTransformationError(self):
         """
         Get the error of the transformation

--- a/msproteomicstoolslib/format/SWATHScoringMapper.py
+++ b/msproteomicstoolslib/format/SWATHScoringMapper.py
@@ -461,6 +461,7 @@ def getPrecursorTransitionMapping(filename):
     query = """
     SELECT PRECURSOR.ID AS transition_group_id,
     TRANSITION_PRECURSOR_MAPPING.TRANSITION_ID AS transition_id,
+    PRECURSOR_PEPTIDE_MAPPING.PEPTIDE_ID AS peptide_id,
     PEPTIDE.MODIFIED_SEQUENCE AS sequence,
     PRECURSOR.CHARGE AS charge
     FROM PRECURSOR
@@ -477,13 +478,14 @@ def getPrecursorTransitionMapping(filename):
             continue
         trgr_id = int(this_row[0])
         transition_id = int(this_row[1])
+        peptide_id = int(this_row[2])
         # Add transition_group_id to precursors_mapping if not present.
         if trgr_id not in precursors_mapping:
-            precursors_mapping[trgr_id] = []
+            precursors_mapping[trgr_id] = (peptide_id, [])
         # Get the transition mapping.
-        tmp = precursors_mapping.get(trgr_id, [])
+        tmp = precursors_mapping.get(trgr_id, (peptide_id, []))[1]
         if transition_id not in tmp:
-            precursors_mapping[trgr_id].append(transition_id)
+            precursors_mapping[trgr_id][1].append(transition_id)
     conn.close()
     return precursors_mapping
 

--- a/msproteomicstoolslib/format/SWATHScoringMapper.py
+++ b/msproteomicstoolslib/format/SWATHScoringMapper.py
@@ -472,6 +472,7 @@ def getPrecursorTransitionMapping(filename):
     """
 
     precursors_mapping = {}
+    precursors_sequence = {}
     data = [row for row in c.execute(query)]
     for this_row in data:
         if len(this_row) == 0: 
@@ -479,15 +480,18 @@ def getPrecursorTransitionMapping(filename):
         trgr_id = int(this_row[0])
         transition_id = int(this_row[1])
         peptide_id = int(this_row[2])
+        sequence = this_row[3]
+        charge = this_row[4]
         # Add transition_group_id to precursors_mapping if not present.
         if trgr_id not in precursors_mapping:
-            precursors_mapping[trgr_id] = (peptide_id, [])
+            precursors_sequence[trgr_id] = (peptide_id, sequence, charge)
+            precursors_mapping[trgr_id] = []
         # Get the transition mapping.
-        tmp = precursors_mapping.get(trgr_id, (peptide_id, []))[1]
+        tmp = precursors_mapping.get(trgr_id, [])
         if transition_id not in tmp:
-            precursors_mapping[trgr_id][1].append(transition_id)
+            precursors_mapping[trgr_id].append(transition_id)
     conn.close()
-    return precursors_mapping
+    return precursors_mapping, precursors_sequence
 
 def create_connection(db_file):
     import sqlite3

--- a/msproteomicstoolslib/format/SWATHScoringReader.py
+++ b/msproteomicstoolslib/format/SWATHScoringReader.py
@@ -821,21 +821,21 @@ class PeakviewPP_SWATHScoringReader(Peakview_SWATHScoringReader):
 
 def getMapping(chromatogramFiles, featureFiles, useCython = False):
     """
-    This function infer mapping between raw chromatogram files and feature files.
+    Returns a dictionary of feature files with Run objects. Only those Runs are included which
+    have corresponding mzML files available.
     Sometimes, a single feature file is provided for all chromatogram files, this function checks
-    whether there is corresponding feature file present for each chromatogram file.
-    It returns a dictionary with keys named as run# and values being a tuple of (chromatogram file, DIA file, feature file).
-
+    whether there is corresponding chromatogram file present for each run.
+    
     >>> chromatogramFiles = ["file1.chrom.mzML", "file2.chrom.mzML"]
     >>> featureFiles = ["file1.osw", "file2.osw"]
     >>> featureFiles_chromFiles_map = getMapping(chromatogramFiles, featureFiles)
-    >>> {"file1" : ("file1.mzML", run1), "file2" : ("file2.mzML", run2)}
+    >>> {"file1.osw" : [run1], "file2.osw" : [run2]}
     """
 
-    # Read osw file. Create a dictionary of "Spectra file": Run()
+    # Read osw file. Create a dictionary of "Feature file": Run()
     MS_feature_fileMapping = getRunfromFeatureFile(featureFiles, useCython)
 
-    # Read mzML, get a dictionary of all provided mzML file.
+    # Read mzML, get a list of all provided mzML file.
     chromFiles = []
     for filename in chromatogramFiles:
         base_name = getBaseName(filename)
@@ -845,7 +845,7 @@ def getMapping(chromatogramFiles, featureFiles, useCython = False):
             chromFiles.append(base_name)
 
     # Iterate through the osw file and find associated mzML file.
-    # Throw warning with filename is a pair is missing.
+    # Remove Run from the dictionary if mzML file is missing and Throw warning.
     # Add to the final dictionary if the basename has associated chromatogram file and OpenSWATH feature file.
 
     for featureFile, runs in MS_feature_fileMapping.items():
@@ -865,13 +865,11 @@ def getMapping(chromatogramFiles, featureFiles, useCython = False):
 
 def getRunfromFeatureFile(featureFiles, useCython = False):
     """
-    Return as dictionary with key as mass-spectra file and value as associated feature file.
+    Return as dictionary with key as feature file and value as associated Run objects.
 
     >>> featureFiles = ["merged.osw"]
     >>> fileMapping = getRunfromFeatureFile(featureFiles)
-    >>> fileMapping["file1.mzML.gz"].get_openswath_filename()
-    >>> fileMapping["file1.mzML.gz"].get_original_filename()
-    >>> fileMapping['file1.mzML.gz'].get_id()
+    >>> fileMapping = {"merged.osw": [Run0, Run1, Run2]}
     """
 
     import sqlite3

--- a/msproteomicstoolslib/format/SWATHScoringReader.py
+++ b/msproteomicstoolslib/format/SWATHScoringReader.py
@@ -154,7 +154,10 @@ class SWATHScoringReader:
                 stdout.write("\rReading %s" % str(f))
                 stdout.flush()
             if f.endswith(".osw"):
-                read += self.parse_file(f, runs, useCython)
+                if not self.infiles_chromfiles_map:
+                    read += self.parse_file(f, runs, useCython)
+                else:
+                    read += self.parse_file_selective(f, runs, useCython)
                 continue
 
             header_dict = {}
@@ -211,6 +214,13 @@ class SWATHScoringReader:
         if verbosity >= 10: stdout.write("\r\r\n") # clean up
         print("Found %s runs, read %s lines and skipped %s lines" % (len(runs), read, skipped))
         return runs
+    
+    def map_infiles_chromfiles(self, chromatogramFiles, useCython=False):
+        """
+        Updates the infiles_chromfiles_map with a dictionary. The dictionary has a mapping between each feature
+        file (osw) and chromatogram file (chrom.mzML).
+        """
+        self.infiles_chromfiles_map = getMapping(chromatogramFiles, self.infiles, useCython = False)
 
 class OpenSWATH_OSW_SWATHScoringReader(SWATHScoringReader):
     """
@@ -226,6 +236,7 @@ class OpenSWATH_OSW_SWATHScoringReader(SWATHScoringReader):
         self.errorHandling = errorHandling
         self.sequence_col = "Sequence"
         self.read_cluster_id = read_cluster_id
+        self.infiles_chromfiles_map = {}
         if readmethod == "cminimal":
             try:
                 from msproteomicstoolslib.cython.Precursor import CyPrecursor
@@ -272,6 +283,26 @@ class OpenSWATH_OSW_SWATHScoringReader(SWATHScoringReader):
             nrows += self._parse_file(filename, current_run, runid, conn)
         return nrows
 
+    def parse_file_selective(self, filename, runs, useCython):
+        """
+        Parse a OSW file. Pick runs that has corresponding mzML file. 
+        """
+
+        nrows = 0
+        if filename not in self.infiles_chromfiles_map:
+            return nrows
+
+        import sqlite3
+        conn = sqlite3.connect(filename)
+
+        # Retrieve available runs from the dictionary and then iterate over them
+        for current_run in self.infiles_chromfiles_map[filename]:
+            runid = current_run.get_id()
+            runs.append(current_run)
+            nrows += self._parse_file(filename, current_run, runid, conn)
+        conn.close()
+        return nrows
+
     def _parse_file(self, filename, run, run_id, conn):
 
         # Make sure the correct indices exist
@@ -284,7 +315,7 @@ class OpenSWATH_OSW_SWATHScoringReader(SWATHScoringReader):
             CREATE INDEX IF NOT EXISTS idx_feature_ms2_feature_id ON FEATURE_MS2 (FEATURE_ID);
             CREATE INDEX IF NOT EXISTS idx_score_ms2_feature_id ON SCORE_MS2 (FEATURE_ID);
         ''')
-
+        # TODO: Shubham: Add left width and right width
         query = """
         SELECT PRECURSOR.ID, SCORE_MS2.QVALUE, FEATURE.EXP_RT, PRECURSOR.DECOY, PEPTIDE.MODIFIED_SEQUENCE, PEPTIDE.ID, FEATURE.ID, AREA_INTENSITY, SCORE_MS2.SCORE
         FROM SCORE_MS2
@@ -318,6 +349,8 @@ class OpenSWATH_OSW_SWATHScoringReader(SWATHScoringReader):
                 decoy = "TRUE"
             else:
                 raise Exception("Unknown decoy", row[3])
+            # left_width = run [8]
+            # right_width = run [9]
 
             # If the peptide does not yet exist, generate it
             if not run.hasPrecursor(peptide_group_label, trgr_id):
@@ -786,3 +819,96 @@ class PeakviewPP_SWATHScoringReader(Peakview_SWATHScoringReader):
             peakgroup.setClusterID(cluster_id)
             run.getPrecursor(peptide_group_label, trgr_id).add_peakgroup(peakgroup)
 
+def getMapping(chromatogramFiles, featureFiles, useCython = False):
+    """
+    This function infer mapping between raw chromatogram files and feature files.
+    Sometimes, a single feature file is provided for all chromatogram files, this function checks
+    whether there is corresponding feature file present for each chromatogram file.
+    It returns a dictionary with keys named as run# and values being a tuple of (chromatogram file, DIA file, feature file).
+
+    >>> chromatogramFiles = ["file1.chrom.mzML", "file2.chrom.mzML"]
+    >>> featureFiles = ["file1.osw", "file2.osw"]
+    >>> featureFiles_chromFiles_map = getMapping(chromatogramFiles, featureFiles)
+    >>> {"file1" : ("file1.mzML", run1), "file2" : ("file2.mzML", run2)}
+    """
+
+    # Read osw file. Create a dictionary of "Spectra file": Run()
+    MS_feature_fileMapping = getRunfromFeatureFile(featureFiles, useCython)
+
+    # Read mzML, get a dictionary of all provided mzML file.
+    chromFiles = []
+    for filename in chromatogramFiles:
+        base_name = getBaseName(filename)
+        if base_name in chromFiles:
+            print(str(filename) + " has basename same as of another mzML file. Basename is obtained by removing directory separator, .gz, .sqMass, .mzML and .chrom extensions.")
+        else:
+            chromFiles.append(base_name)
+
+    # Iterate through the osw file and find associated mzML file.
+    # Throw warning with filename is a pair is missing.
+    # Add to the final dictionary if the basename has associated chromatogram file and OpenSWATH feature file.
+
+    for featureFile, runs in MS_feature_fileMapping.items():
+        for run in runs:
+            MSrun = getBaseName(run.get_openswath_filename())
+            if(MSrun not in chromFiles):
+                # Warning
+                print("Chromatogram file associated with " + run.get_openswath_filename() + " from " + run.get_original_filename() + " is not found. Skipping!")
+                MS_feature_fileMapping[featureFile].remove(run)
+        if len(MS_feature_fileMapping[featureFile]) == 0:
+            del MS_feature_fileMapping[featureFile]
+    
+    if not MS_feature_fileMapping:
+        # Error
+        raise Exception("Feature files and chromatogram files do not have matching names.")
+    return MS_feature_fileMapping
+
+def getRunfromFeatureFile(featureFiles, useCython = False):
+    """
+    Return as dictionary with key as mass-spectra file and value as associated feature file.
+
+    >>> featureFiles = ["merged.osw"]
+    >>> fileMapping = getRunfromFeatureFile(featureFiles)
+    >>> fileMapping["file1.mzML.gz"].get_openswath_filename()
+    >>> fileMapping["file1.mzML.gz"].get_original_filename()
+    >>> fileMapping['file1.mzML.gz'].get_id()
+    """
+
+    import sqlite3
+    MSfile_featureFile_mapping = {}
+    for filename in featureFiles:
+        MSfile_featureFile_mapping[filename] = []
+        conn = sqlite3.connect(filename)
+        c = conn.cursor()
+        try:
+            # Retrieve and then iterate over all available runs
+            query = """SELECT ID, FILENAME FROM RUN"""
+            results = [row for row in c.execute(query)]
+            for (run_id, MS_file) in results:
+                current_run = Run([], {}, run_id, filename, MS_file, MS_file, useCython=useCython)
+                MSfile_featureFile_mapping[filename].append(current_run)
+        
+        except sqlite3.Error as e:
+            print("An error occured in reading file " + str(filename) + ", ", e.args[0])
+            conn.close()
+                
+        # Close the connection
+        conn.close()
+    return MSfile_featureFile_mapping
+
+def getBaseName(filename):
+    """
+    Returns a basename for filename. Basename is obtained by removing directory separator, .gz, .sqMass, .mzML and .chrom extensions.
+    
+    >>> getBaseName('data/raw/hroest_K120808_Strep10%PlasmaBiolRepl1_R03_SW_filt.mzML.gz')
+    >>> hroest_K120808_Strep10%PlasmaBiolRepl1_R03_SW_filt
+    """
+
+    fileBase = filename
+    # Remove directory separator from filename
+    for dir_sep in ["/", "\\"]:
+        fileBase = fileBase.split(dir_sep)[-1]
+    # First remove gz, then sqmass, then mzML & then chrom, if present.
+    for ending in [".gz", ".sqMass", ".mzML", ".chrom"]:
+        fileBase = fileBase.split(ending)[0]
+    return fileBase

--- a/msproteomicstoolslib/format/TransformationCollection.py
+++ b/msproteomicstoolslib/format/TransformationCollection.py
@@ -39,6 +39,20 @@ from __future__ import print_function
 import msproteomicstoolslib.math.Smoothing as smoothing
 import numpy
 
+def initialize_transformation():
+    # Initialize objects to get transformation
+    try:
+        from msproteomicstoolslib.cython.LightTransformationData import CyLightTransformationData
+        if optimized_cython:
+            tr_data = CyLightTransformationData()
+        else:
+            tr_data = LightTransformationData()
+    except ImportError:
+        print("WARNING: cannot import CyLightTransformationData, will use Python version (slower).")
+        tr_data = LightTransformationData()
+    return tr_data
+
+
 class LightTransformationData:
     """
     A lightweight data structure to store a transformation between retention times of multiple runs.

--- a/msproteomicstoolslib/math/ChromatogramSmoothing.py
+++ b/msproteomicstoolslib/math/ChromatogramSmoothing.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""
+=========================================================================
+        DIAlignPy -- Alignment of Targeted Mass Spectrometry Runs
+=========================================================================
+
+<Shubham Gupta ChromatogramSmoothing.py>
+Copyright (C) 2020 Shubham Gupta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+--------------------------------------------------------------------------
+$Maintainer: Shubham Gupta$
+$Authors: Shubham Gupta$
+--------------------------------------------------------------------------
+"""
+import numpy as np
+import math
+from msproteomicstoolslib.math.Smoothing import LowessSmoothingBase
+from scipy.signal import savgol_filter
+from scipy.ndimage import gaussian_filter1d
+
+def getXIC_SmoothingObj(smoother, kernelLen = 13, polyOrd = 4):
+    if smoother == "sgolay":
+        return SgolaySmooth(kernelLen, polyOrd)
+    elif smoother == "gaussian":
+        return GaussianSmooth(kernelLen)
+    elif smoother == "loess":
+        return LoessSmooth(kernelLen, polyOrd)
+    else:
+        raise Exception("Unknown chromatogram smoothing method: " + smoother)
+
+class LoessSmooth(LowessSmoothingBase):
+    """Smoothing chromatogram using Lowess smoother and then interpolate on the result
+    """
+
+    def __init__(self, kernelLen, polyOrd):
+        self.kernelLen = kernelLen
+        self.polyOrd = polyOrd
+
+    def _initialize(self, data1, data2):
+        try:
+            import statsmodels.api as sm
+            lowess = sm.nonparametric.lowess
+        except ImportError:
+            print("===================================")
+            print("Cannot import the module lowess from 'statsmodels', \nplease install the Python package 'statsmodels'")
+            print("===================================")
+        
+        if len(data2) < 100:
+            frac = 1.0
+        else:
+            frac = self.kernelLen / len(data1)
+
+        k = 0
+        while k <= 10:
+            k += 1
+            # Input data is y/x -> needs switch
+            result = lowess(np.array(data2), np.array(data1), delta=0.0, frac=frac, it=0)
+
+            if any( [math.isnan(r[1]) for r in result] ):
+                print ("WARNING: lowess returned NA data points! We are trying to fix it")
+                result = lowess(np.array(data2), np.array(data1), delta=0.0, frac=frac, it=10)
+                frac = 1.0
+            else:
+                break
+
+        return [ r[0] for r in result], [r[1] for r in result]
+    
+    def smooth(self, xhat, yhat):
+        return xhat, np.array(self.predict(xhat))
+
+class SgolaySmooth:
+    """Savitzky-Golay smoothing. It preserves the peak shape"""
+    def __init__(self, kernelLen, polyOrd):
+        if (kernelLen % 2) == 0:
+            raise Exception("kernel length must be odd for Savitzky- Golay smoothing.")
+        if not (kernelLen > polyOrd):
+            raise Exception("polyOrd must be less than the kernel length for Savitzky- Golay smoothing.")
+        self.window_length = kernelLen
+        self.polyorder = polyOrd
+
+    def initialize(self, data1, data2):
+        pass
+
+    def smooth(self, xhat, yhat):
+        return xhat, savgol_filter(np.array(yhat), self.window_length, self.polyorder)
+
+class GaussianSmooth:
+    """
+    Gaussian smoothing. The kernelLen indicates Full Width Half Maximum (FWHM) of gaussian kernel.
+    The standard deviation is multiplied with 0.3706505 to be similar to R code
+    https://github.com/shubham1637/DIAlignR/R/chromatogram_smooth.R
+
+    """
+    def __init__(self, kernelLen):
+        # Converting FWHM to standard deviation.
+        sigma = kernelLen / np.sqrt(8 * np.log(2))
+        self.sigma = sigma*0.3706505 # Scaled to have quartiles at +/- 0.25*sigma
+
+    def initialize(self, data1, data2):
+        pass
+
+    def smooth(self, xhat, yhat):
+        return xhat, gaussian_filter1d(np.array(yhat), sigma = self.sigma, mode = 'constant', cval = 0.0)

--- a/msproteomicstoolslib/math/Smoothing.py
+++ b/msproteomicstoolslib/math/Smoothing.py
@@ -929,7 +929,7 @@ class LoessSmooth(LowessSmoothingBase):
         return [ r[0] for r in result], [r[1] for r in result]
     
     def smooth(self, xhat, yhat):
-        return xhat, self.predict(xhat)
+        return xhat, numpy.array(self.predict(xhat))
 
 class SgolaySmooth:
     """Savitzky-Golay smoothing. It preserves the peak shape"""

--- a/msproteomicstoolslib/math/Smoothing.py
+++ b/msproteomicstoolslib/math/Smoothing.py
@@ -911,8 +911,6 @@ class LoessSmooth(LowessSmoothingBase):
         if len(data2) < 100:
             frac = 1.0
         else:
-            print(self.kernelLen)
-            print(len(data1))
             frac = self.kernelLen / len(data1)
 
         k = 0
@@ -923,13 +921,15 @@ class LoessSmooth(LowessSmoothingBase):
 
             if any( [math.isnan(r[1]) for r in result] ):
                 print ("WARNING: lowess returned NA data points! We are trying to fix it")
-                delta = delta * k
-                result = lowess(numpy.array(data2), numpy.array(data1), delta=delta, frac=frac, it=10)
+                result = lowess(numpy.array(data2), numpy.array(data1), delta=0.0, frac=frac, it=10)
                 frac = 1.0
             else:
                 break
 
         return [ r[0] for r in result], [r[1] for r in result]
+    
+    def smooth(self, xhat, yhat):
+        return xhat, self.predict(xhat)
 
 class SgolaySmooth:
     """Savitzky-Golay smoothing. It preserves the peak shape"""
@@ -941,11 +941,11 @@ class SgolaySmooth:
         self.window_length = kernelLen
         self.polyorder = polyOrd
 
-    def initialize(self):
+    def initialize(self, data1, data2):
         pass
 
-    def predict(self, xhat):
-        return savgol_filter(numpy.array(xhat), self.window_length, self.polyorder)
+    def smooth(self, xhat, yhat):
+        return xhat, savgol_filter(numpy.array(yhat), self.window_length, self.polyorder)
 
 class GaussianSmooth:
     """
@@ -959,9 +959,9 @@ class GaussianSmooth:
         sigma = kernelLen / np.sqrt(8 * np.log(2))
         self.sigma = sigma*0.3706505 # Scaled to have quartiles at +/- 0.25*sigma
 
-    def initialize(self):
+    def initialize(self, data1, data2):
         pass
 
-    def predict(self, xhat):
-        return gaussian_filter1d(numpy.array(xhat), sigma = self.sigma, mode = 'constant', cval = 0.0)
+    def smooth(self, xhat, yhat):
+        return xhat, gaussian_filter1d(numpy.array(yhat), sigma = self.sigma, mode = 'constant', cval = 0.0)
 

--- a/msproteomicstoolslib/math/Smoothing.py
+++ b/msproteomicstoolslib/math/Smoothing.py
@@ -43,8 +43,7 @@ import math
 import random
 import numpy as np
 from numpy import median, absolute
-from scipy.signal import savgol_filter
-from scipy.ndimage import gaussian_filter1d
+
 
 def get_smooting_operator(use_scikit=False, use_linear=False, use_external_r = False, tmpdir=None):
   if use_linear: 
@@ -100,16 +99,6 @@ def getSmoothingObj(smoother, topN=5, max_rt_diff=30, min_rt_diff=0.1, removeOut
         return SmoothingNull()
     else:
         raise Exception("Unknown smoothing method: " + smoother)
-
-def getXIC_SmoothingObj(smoother, kernelLen = 13, polyOrd = 4):
-    if smoother == "sgolay":
-        return SgolaySmooth(kernelLen, polyOrd)
-    elif smoother == "gaussian":
-        return GaussianSmooth(kernelLen)
-    elif smoother == "loess":
-        return LoessSmooth(kernelLen, polyOrd)
-    else:
-        raise Exception("Unknown chromatogram smoothing method: " + smoother)
 
 class SmoothingR:
     """Class to smooth data using the smooth.spline function from R
@@ -890,78 +879,4 @@ class SmoothLLDMedian(LocalKernel):
             res.append( expected_targ )
 
         return res
-
-class LoessSmooth(LowessSmoothingBase):
-    """Smoothing chromatogram using Lowess smoother and then interpolate on the result
-    """
-
-    def __init__(self, kernelLen, polyOrd):
-        self.kernelLen = kernelLen
-        self.polyOrd = polyOrd
-
-    def _initialize(self, data1, data2):
-        try:
-            import statsmodels.api as sm
-            lowess = sm.nonparametric.lowess
-        except ImportError:
-            print("===================================")
-            print("Cannot import the module lowess from 'statsmodels', \nplease install the Python package 'statsmodels'")
-            print("===================================")
-        
-        if len(data2) < 100:
-            frac = 1.0
-        else:
-            frac = self.kernelLen / len(data1)
-
-        k = 0
-        while k <= 10:
-            k += 1
-            # Input data is y/x -> needs switch
-            result = lowess(numpy.array(data2), numpy.array(data1), delta=0.0, frac=frac, it=0)
-
-            if any( [math.isnan(r[1]) for r in result] ):
-                print ("WARNING: lowess returned NA data points! We are trying to fix it")
-                result = lowess(numpy.array(data2), numpy.array(data1), delta=0.0, frac=frac, it=10)
-                frac = 1.0
-            else:
-                break
-
-        return [ r[0] for r in result], [r[1] for r in result]
-    
-    def smooth(self, xhat, yhat):
-        return xhat, numpy.array(self.predict(xhat))
-
-class SgolaySmooth:
-    """Savitzky-Golay smoothing. It preserves the peak shape"""
-    def __init__(self, kernelLen, polyOrd):
-        if (kernelLen % 2) == 0:
-            raise Exception("kernel length must be odd for Savitzky- Golay smoothing.")
-        if not (kernelLen > polyOrd):
-            raise Exception("polyOrd must be less than the kernel length for Savitzky- Golay smoothing.")
-        self.window_length = kernelLen
-        self.polyorder = polyOrd
-
-    def initialize(self, data1, data2):
-        pass
-
-    def smooth(self, xhat, yhat):
-        return xhat, savgol_filter(numpy.array(yhat), self.window_length, self.polyorder)
-
-class GaussianSmooth:
-    """
-    Gaussian smoothing. The kernelLen indicates Full Width Half Maximum (FWHM) of gaussian kernel.
-    The standard deviation is multiplied with 0.3706505 to be similar to R code
-    https://github.com/shubham1637/DIAlignR/R/chromatogram_smooth.R
-
-    """
-    def __init__(self, kernelLen):
-        # Converting FWHM to standard deviation.
-        sigma = kernelLen / np.sqrt(8 * np.log(2))
-        self.sigma = sigma*0.3706505 # Scaled to have quartiles at +/- 0.25*sigma
-
-    def initialize(self, data1, data2):
-        pass
-
-    def smooth(self, xhat, yhat):
-        return xhat, gaussian_filter1d(numpy.array(yhat), sigma = self.sigma, mode = 'constant', cval = 0.0)
 

--- a/msproteomicstoolslib/util/utils.py
+++ b/msproteomicstoolslib/util/utils.py
@@ -230,3 +230,19 @@ class csv_table:
             res = [ tmp[i] for tmp in self.rows]
         return res
 
+def getBaseName(filename):
+    """
+    Returns a basename for filename. Basename is obtained by removing directory separator, .gz, .sqMass, .mzML and .chrom extensions.
+    
+    >>> getBaseName('data/raw/hroest_K120808_Strep10%PlasmaBiolRepl1_R03_SW_filt.mzML.gz')
+    >>> hroest_K120808_Strep10%PlasmaBiolRepl1_R03_SW_filt
+    """
+
+    fileBase = filename
+    # Remove directory separator from filename
+    for dir_sep in ["/", "\\"]:
+        fileBase = fileBase.split(dir_sep)[-1]
+    # First remove gz, then sqmass, then mzML & then chrom, if present.
+    for ending in [".gz", ".sqMass", ".mzML", ".chrom"]:
+        fileBase = fileBase.split(ending)[0]
+    return fileBase

--- a/msproteomicstoolslib/version.py
+++ b/msproteomicstoolslib/version.py
@@ -36,5 +36,5 @@ $Authors: Hannes Roest$
 """
 from __future__ import print_function
 
-__version__ = (0, 11, 0)
+__version__ = (1, 2, 0)
 


### PR DESCRIPTION
The following workflow is added:
- Fetch transition IDs for each precursor from .osw file.
- Fetch respective chromatogram IDs in each .mzML file.
- Implemented a reference-based alignment. For each precursor, a reference is calculated using FDR score.
- Chromatograms are fetched using pyopenms and aligned using DIAlignPy.
- Retention time is mapped from reference run and a peak-group closest to it within a certain window is quantified.